### PR TITLE
Updated link to DASHIF-IOP Guidelines

### DIFF
--- a/index.html
+++ b/index.html
@@ -775,7 +775,7 @@
           <p>
           Unfortunately, neither DASH or <a>HLS</a> do currently specify a way to
           reference thumbnail images directly from manifests. However, the
-          DASH-IF Guidelines [[DASHIFIOP]] describe an extension to
+          <a href="https://dash-industry-forum.github.io/docs/DASH-IF-IOP-v4.2-clean.pdf">DASH-IF Guidelines</a> describe an extension to
           reference thumbnail images. The thumbnails would be exposed as single
           or gridded images. All parameters required to load and display the
           thumbnail images are contained in the Manifest. This approach


### PR DESCRIPTION
Fixes #86 

Unfortunatley I could not find a reference to the latest DASH-IF IOP
guidelines in refspec. Instead I replaced the reference with a link to
the 4.2 guideline specs.